### PR TITLE
Add Stormer-Verlet notebook.

### DIFF
--- a/notebooks/Stormer-Verlet.ipynb
+++ b/notebooks/Stormer-Verlet.ipynb
@@ -1,0 +1,229 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "932f3d29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up required packages\n",
+    "using Pkg\n",
+    "Pkg.activate(@__DIR__)\n",
+    "Pkg.instantiate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88a0891c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load packages\n",
+    "using BSeries\n",
+    "using SymPy\n",
+    "using Latexify\n",
+    "using LinearAlgebra"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7593a1e",
+   "metadata": {},
+   "source": [
+    "Here we study the Stormer-Verlet method applied to the Kepler Problem:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c40d752",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Kepler problem\n",
+    "function f_p(q, p)\n",
+    "  (-1 / sqrt(q[1]^2 + q[2]^2)^3) .* q\n",
+    "end\n",
+    "\n",
+    "function f_q(q, p)\n",
+    "  p\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5bd8dc7b",
+   "metadata": {},
+   "source": [
+    "Stormer-Verlet is most naturally seen as a partitioned method, but can also be cast as an additive Runge-Kutta method using the kind of splitting defined above, and with the coefficients below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b91d5b3f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Störmer-Verlet method as additive RK method, see\n",
+    "# Hairer, Lubich, Wanner (2002)\n",
+    "# Geometric numerical integration\n",
+    "# Table II.2.1\n",
+    "As = [\n",
+    "    [0 0; 1//2 1//2],\n",
+    "    [1//2 0; 1//2 0],\n",
+    "]\n",
+    "bs = [\n",
+    "    [1//2, 1//2],\n",
+    "    [1//2, 1//2]\n",
+    "]\n",
+    "ark = AdditiveRungeKuttaMethod(As, bs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "564786cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up symbolic equation\n",
+    "dt_sym = symbols(\"h\", real=true)\n",
+    "q_sym = symbols(\"q_1, q_2\", real=true)\n",
+    "p_sym = symbols(\"p_1, p_2\", real=true)\n",
+    "u_sym = [q_sym..., p_sym...]\n",
+    "f_q_sym = [f_q(q_sym, p_sym)..., 0, 0]\n",
+    "f_p_sym = [0, 0, f_p(q_sym, p_sym)...]\n",
+    "f_sym = (f_q_sym, f_p_sym)\n",
+    "\n",
+    "# Compute B-series of the numerical integrator and the modified equation\n",
+    "truncation_order = 8\n",
+    "series_integrator = bseries(ark, truncation_order)\n",
+    "series = modified_equation(f_sym, u_sym, dt_sym, series_integrator);\n",
+    "\n",
+    "#println(\"Modifying integrator equation for \", u_sym[1], \":\")\n",
+    "#println(latexify(series[1], cdot=false))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07dda62d",
+   "metadata": {},
+   "source": [
+    "We've computed the modified equation up to order $h^8$.  Now we check that it contains no terms proportional to odd powers of $h$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c49fe72",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expr = SymPy.collect(series[1],dt_sym)\n",
+    "for j in 0:3\n",
+    "    println(expr.coeff(dt_sym,2*j+1), \" \", dt_sym^(2*j+1))\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d7939eb",
+   "metadata": {},
+   "source": [
+    "We've only checked the flow for $q_1$; the other elements of the RHS can be checked similarly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8969adf",
+   "metadata": {},
+   "source": [
+    "Next we'll compute the modifying integrator, this time only up to order $h^4$ to avoid printing out extremely long expressions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "94116363",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up symbolic equation\n",
+    "dt_sym = symbols(\"h\", real=true)\n",
+    "q_sym = symbols(\"q_1, q_2\", real=true)\n",
+    "p_sym = symbols(\"p_1, p_2\", real=true)\n",
+    "u_sym = [q_sym..., p_sym...]\n",
+    "f_q_sym = [f_q(q_sym, p_sym)..., 0, 0]\n",
+    "f_p_sym = [0, 0, f_p(q_sym, p_sym)...]\n",
+    "f_sym = (f_q_sym, f_p_sym)\n",
+    "\n",
+    "# Compute B-series of the numerical integrator and the modified equation\n",
+    "truncation_order = 4\n",
+    "series_integrator = bseries(ark, truncation_order)\n",
+    "series = modifying_integrator(f_sym, u_sym, dt_sym, series_integrator);\n",
+    "\n",
+    "println(\"Modifying integrator RHS for \", u_sym[1], \":\")\n",
+    "series[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a536321e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "println(\"Modifying integrator equation for \", u_sym[2], \":\")\n",
+    "series[2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7508f02",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "println(\"Modifying integrator equation for \", u_sym[3], \":\")\n",
+    "series[3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5289fb22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "println(\"Modifying integrator equation for \", u_sym[4], \":\")\n",
+    "series[4]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9981de83",
+   "metadata": {},
+   "source": [
+    "Unfortunately, this system does not have the structure that enables the Stormer-Verlet method to be implemented in explicit fashion."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 1.7.2",
+   "language": "julia",
+   "name": "julia-1.7"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.7.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This adds a notebook that includes the calculations relevant to Stormer-Verlet in the paper.  See https://github.com/ketch/2021_bseries_paper/pull/31/.